### PR TITLE
Allow to restore previous state

### DIFF
--- a/src/scripts/h5p-multi-media-choice-content.js
+++ b/src/scripts/h5p-multi-media-choice-content.js
@@ -12,8 +12,9 @@ export default class MultiMediaChoiceContent {
    * @param {number} contentId Content's id.
    * @param {object} [callbacks = {}] Callbacks.
    * @param {string} assetsFilePath File path to the assets folder
+   * @param {object} previousState Previous state.
    */
-  constructor(params = {}, contentId, callbacks = {}, assetsFilePath) {
+  constructor(params = {}, contentId, callbacks = {}, assetsFilePath, previousState) {
     this.params = params;
     this.contentId = contentId;
     this.callbacks = callbacks;
@@ -84,6 +85,12 @@ export default class MultiMediaChoiceContent {
           )
       )
       : [];
+
+    // Restore previous state
+    (previousState.answers || []).forEach(previouslySelectedIndex => {
+      this.toggleSelected(previouslySelectedIndex);
+    });
+
     this.optionList = this.buildOptionList(this.options);
     this.content.appendChild(this.optionList);
     this.setTabIndexes();

--- a/src/scripts/h5p-multi-media-choice.js
+++ b/src/scripts/h5p-multi-media-choice.js
@@ -71,7 +71,8 @@ export default class MultiMediaChoice extends H5P.Question {
             this.triggerXAPI('interacted');
           }
         },
-        this.getLibraryFilePath('assets')
+        this.getLibraryFilePath('assets'),
+        this.extras.previousState || {}
       );
 
       this.setContent(this.content.getDOM()); // Register content with H5P.Question


### PR DESCRIPTION
It seems that `getCurrentState` was implemented, but the previous state was never restored.

When merged in, the previously selected options will be selected based on the previous state.