### PR TITLE
HFP-3682 Improve getAnswerGiven

### DIFF
--- a/src/scripts/h5p-multi-media-choice-content.js
+++ b/src/scripts/h5p-multi-media-choice-content.js
@@ -426,10 +426,6 @@ export default class MultiMediaChoiceContent {
    * @return {boolean} true if answers have been given, else false
    */
   getAnswerGiven() {
-    if (!this.isAnyAnswerSelected()) {
-      return false;
-    }
-    return true;
-
+    return this.isAnyAnswerSelected() || this.isBlankCorrect();
   }
 }

--- a/src/scripts/h5p-multi-media-choice.js
+++ b/src/scripts/h5p-multi-media-choice.js
@@ -84,15 +84,6 @@ export default class MultiMediaChoice extends H5P.Question {
     };
 
     /**
-     * Check if result has been submitted or input has been given.
-     * @return {boolean} True if answer was given
-     * @see contract at {@link https://h5p.org/documentation/developers/contracts#guides-header-1}
-     */
-    this.getAnswersGiven = () => {
-      return this.content.isAnyAnswerSelected() || this.content.isBlankCorrect();
-    };
-
-    /**
      * Get latest score
      * @return {number} latest score
      * @see contract at {@link https://h5p.org/documentation/developers/contracts#guides-header-2}
@@ -170,7 +161,7 @@ export default class MultiMediaChoice extends H5P.Question {
       // require input for solution behavior is not valid if the request is originated
       // from compound content type
       if (this.params.behaviour.showSolutionsRequiresInput
-        && !this.content.isAnyAnswerSelected() 
+        && !this.content.isAnyAnswerSelected()
         && shouldRespectRequireInputFlag) {
         // Require answer before solution can be viewed
         this.updateFeedbackContent(this.params.l10n.noAnswer);


### PR DESCRIPTION
When merged in, will fix the issue reported in HFP-3682. The behavior for `getAnswerGiven` will be the same as in MultiChoice or MarkTheWords or DragQuestion for questions where picking no answer option is the correct choice.

However, that behavior for `getAnswerGiven` will lead to seemingly weird behavior in Question Set for all of the subcontent types if no answer option is correct. In that case, the progress dots for questions within QuestionSet will be set on startup already without any user interaction necessary. It should be verified if that is in fact the intended behavior for QuestionSet and for the subcontent types.