### PR TITLE
Assign unique ids to multimedia choice content types

### DIFF
--- a/src/scripts/h5p-multi-media-choice-content.js
+++ b/src/scripts/h5p-multi-media-choice-content.js
@@ -14,14 +14,16 @@ export default class MultiMediaChoiceContent {
    * @param {object} [callbacks = {}] Callbacks.
    * @param {string} assetsFilePath File path to the assets folder
    * @param {number[]} answerState Previous answers given (when resuming)
+   * @param {number} introId id for the title text
    */
-  constructor(params = {}, contentId, callbacks = {}, answerState) {
+  constructor(params = {}, contentId, callbacks = {}, answerState, introId) {
     this.params = params;
     this.contentId = contentId;
     this.callbacks = callbacks;
     this.callbacks.triggerResize = this.callbacks.triggerResize || (() => {});
     this.callbacks.triggerInteracted = this.callbacks.triggerInteracted || (() => {});
     this.maxAlternativesPerRow = this.params.behaviour.maxAlternativesPerRow;
+    this.introId = introId;
 
     this.numberOfCorrectOptions = params.options
       ? params.options.filter(option => option.correct).length
@@ -110,7 +112,7 @@ export default class MultiMediaChoiceContent {
       classList: ['h5p-multi-media-choice-option-list'],
       attributes: {
         role: this.isSingleAnswer ? 'radiogroup' : 'group',
-        'aria-labelledby': `h5p-media-choice${this.contentId}`
+        'aria-labelledby': `h5p-media-choice-${this.introId}`
       }
     });
 

--- a/src/scripts/h5p-multi-media-choice.js
+++ b/src/scripts/h5p-multi-media-choice.js
@@ -19,6 +19,7 @@ export default class MultiMediaChoice extends H5P.Question {
     this.contentId = contentId;
     this.extras = extras;
     this.answerState = extras.previousState && extras.previousState.answers ? extras.previousState.answers : [];
+    this.introId = Date.now();
 
     // Default values are extended
     this.params = Util.extendParams(params);
@@ -43,7 +44,8 @@ export default class MultiMediaChoice extends H5P.Question {
           this.triggerXAPI('interacted');
         }
       },
-      this.answerState
+      this.answerState,
+      this.introId
     );
 
     this.registerDomElements = () => {
@@ -78,7 +80,7 @@ export default class MultiMediaChoice extends H5P.Question {
 
       // Register task introduction text
       if (this.params.question) {
-        this.introduction = createElement({type: 'div', attributes: {id: `h5p-media-choice${contentId}`}});
+        this.introduction = createElement({type: 'div', attributes: {id: `h5p-media-choice-${this.introId}`}});
         this.introduction.innerHTML = this.params.question;
         this.setIntroduction(this.introduction);
       }
@@ -224,7 +226,11 @@ export default class MultiMediaChoice extends H5P.Question {
     this.getAnswerGiven = () => {
       return this.content.getAnswerGiven();
     };
+
+    H5P.MultiMediaChoice.counter = (H5P.MultiMediaChoice.counter === undefined ? 0 : H5P.MultiMediaChoice.counter + 1);
+    this.params.labelId = 'h5p-mmcq' + H5P.MultiMediaChoice.counter;
   }
+
 
   /**
    * Add the buttons that are passed to H5P.Question

--- a/src/scripts/h5p-multi-media-choice.js
+++ b/src/scripts/h5p-multi-media-choice.js
@@ -226,11 +226,7 @@ export default class MultiMediaChoice extends H5P.Question {
     this.getAnswerGiven = () => {
       return this.content.getAnswerGiven();
     };
-
-    H5P.MultiMediaChoice.counter = (H5P.MultiMediaChoice.counter === undefined ? 0 : H5P.MultiMediaChoice.counter + 1);
-    this.params.labelId = 'h5p-mmcq' + H5P.MultiMediaChoice.counter;
   }
-
 
   /**
    * Add the buttons that are passed to H5P.Question


### PR DESCRIPTION
https://h5ptechnology.atlassian.net/browse/HFP-4121

This PR fixes an issue where intro text id's of Multi-Media choice content types in a Question set reference the Question set title, meaning Multi-Media choice content types in a Question set shared id's, resulting in screenreaders reading the title of the first Multi-Media choice content type for every instance of this type. This PR implements unique id's for Multi-Media choice content types.